### PR TITLE
feat: graceful stop hook (HTTP or command) before Ctrl+C/force-kill

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -192,6 +192,39 @@ interval_seconds = 60
 failure_threshold = 1
 ```
 
+## Graceful Stop Hook
+
+By default, when the service is stopped WinLet sends **Ctrl+C** to the process and force-kills it after
+`shutdown_timeout_seconds`. For a **console-less service child**, that Ctrl+C often cannot be delivered, so
+the process is force-killed — risky for anything mid-write to a database or file.
+
+A **stop hook** lets the managed process shut *itself* down cleanly first. On stop, WinLet invokes the hook
+(an HTTP request or a command) and waits for the process to exit; only if it does not exit within
+`timeout_seconds` does WinLet fall back to Ctrl+C and then a force kill.
+
+### HTTP Stop Hook (call a shutdown endpoint)
+
+```toml
+[process.stop_hook]
+type = "http"
+url = "http://localhost:3000/admin/stop"   # your app's graceful-shutdown endpoint
+method = "POST"                              # default POST
+timeout_seconds = 30                         # wait this long for the process to exit
+```
+
+### Command Stop Hook (run a shutdown command)
+
+```toml
+[process.stop_hook]
+type = "command"
+command = "C:\\Apps\\MyApp\\shutdown.exe"
+arguments = "--graceful"
+timeout_seconds = 30
+```
+
+If the hook is omitted, behavior is unchanged (Ctrl+C → force kill). A failed or missing hook simply falls
+through to the default stop path — the hook never blocks a stop from completing.
+
 ## Service Accounts
 
 ### Local System (Default)

--- a/src/WinLet.Core/ConfigLoader.cs
+++ b/src/WinLet.Core/ConfigLoader.cs
@@ -161,6 +161,9 @@ public class ConfigLoader
         if (processTable.TryGetValue("shutdown_timeout_seconds", out var timeout))
             process.ShutdownTimeoutSeconds = Convert.ToInt32(timeout);
 
+        if (processTable.TryGetValue("stop_hook", out var stopHookObj) && stopHookObj is TomlTable stopHookTable)
+            process.StopHook = MapStopHookConfig(stopHookTable);
+
         // Map environment variables
         if (processTable.TryGetValue("environment", out var envObj) && envObj is TomlTable envTable)
         {
@@ -282,6 +285,26 @@ public class ConfigLoader
             health.FailureThreshold = Convert.ToInt32(threshold);
 
         return health;
+    }
+
+    private static StopHookConfig MapStopHookConfig(TomlTable table)
+    {
+        var hook = new StopHookConfig();
+
+        if (table.TryGetValue("type", out var type) && Enum.TryParse<StopHookType>(type.ToString(), true, out var t))
+            hook.Type = t;
+        if (table.TryGetValue("url", out var url))
+            hook.Url = url.ToString();
+        if (table.TryGetValue("method", out var method))
+            hook.Method = method.ToString() ?? "POST";
+        if (table.TryGetValue("command", out var command))
+            hook.Command = command.ToString();
+        if (table.TryGetValue("arguments", out var args))
+            hook.Arguments = args.ToString();
+        if (table.TryGetValue("timeout_seconds", out var timeout))
+            hook.TimeoutSeconds = Convert.ToInt32(timeout);
+
+        return hook;
     }
 
     private static ServiceAccountConfig MapServiceAccountConfig(TomlTable serviceAccountTable)

--- a/src/WinLet.Core/ProcessRunner.cs
+++ b/src/WinLet.Core/ProcessRunner.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Diagnostics;
+using System.Net.Http;
 using System.Runtime.InteropServices;
 using Microsoft.Extensions.Logging;
 
@@ -206,6 +207,19 @@ public class ProcessRunner : IDisposable
 
         try
         {
+            // Graceful stop hook (if configured): ask the process to shut ITSELF down cleanly before
+            // any signal or kill, so a process mid-write to a DB/file can finish. If it exits within
+            // the hook timeout we are done; otherwise fall through to Ctrl+C -> force kill below.
+            if (_config.Process.StopHook is { } stopHook)
+            {
+                if (await TryStopHookAsync(stopHook, cancellationToken))
+                {
+                    _logger.LogInformation("Process exited gracefully via stop hook");
+                    return;
+                }
+                _logger.LogWarning("Stop hook did not stop the process in time; falling back to signal/kill");
+            }
+
             // Try graceful shutdown first - attempt GUI close
             bool sentGracefulSignal = false;
             
@@ -261,6 +275,87 @@ public class ProcessRunner : IDisposable
         finally
         {
             _cancellationTokenSource.Cancel();
+        }
+    }
+
+    /// <summary>
+    /// Invoke the configured graceful stop hook (an HTTP request or a command) and wait up to the
+    /// hook's timeout for the managed process to exit. Returns true if the process exited — letting
+    /// the caller skip the Ctrl+C / force-kill fallback. Never throws: a failed hook returns false.
+    /// </summary>
+    private async Task<bool> TryStopHookAsync(StopHookConfig hook, CancellationToken cancellationToken)
+    {
+        if (_process == null)
+            return true;
+
+        try
+        {
+            if (hook.Type == StopHookType.Http)
+            {
+                if (string.IsNullOrWhiteSpace(hook.Url))
+                {
+                    _logger.LogWarning("Stop hook type=Http but no url configured; skipping hook");
+                    return false;
+                }
+
+                _logger.LogInformation("Invoking stop hook: {Method} {Url}", hook.Method, hook.Url);
+                using var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(Math.Max(5, hook.TimeoutSeconds)) };
+                using var request = new HttpRequestMessage(new HttpMethod(hook.Method), hook.Url);
+                try
+                {
+                    await httpClient.SendAsync(request, cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning("Stop hook HTTP call failed: {Message}", ex.Message);
+                }
+            }
+            else // Command
+            {
+                if (string.IsNullOrWhiteSpace(hook.Command))
+                {
+                    _logger.LogWarning("Stop hook type=Command but no command configured; skipping hook");
+                    return false;
+                }
+
+                _logger.LogInformation("Invoking stop hook command: {Command} {Arguments}", hook.Command, hook.Arguments);
+                var startInfo = new ProcessStartInfo
+                {
+                    FileName = hook.Command,
+                    Arguments = hook.Arguments ?? string.Empty,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                };
+                try
+                {
+                    using var hookProcess = Process.Start(startInfo);
+                    if (hookProcess != null)
+                        await hookProcess.WaitForExitAsync(cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning("Stop hook command failed: {Message}", ex.Message);
+                }
+            }
+
+            // Wait for the MANAGED process to exit within the hook timeout.
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCts.CancelAfter(TimeSpan.FromSeconds(Math.Max(1, hook.TimeoutSeconds)));
+            try
+            {
+                await _process.WaitForExitAsync(timeoutCts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                // timed out waiting for exit — caller falls back to signal/kill
+            }
+
+            return _process.HasExited;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning("Stop hook error: {Message}", ex.Message);
+            return _process.HasExited;
         }
     }
 

--- a/src/WinLet.Core/ProcessRunner.cs
+++ b/src/WinLet.Core/ProcessRunner.cs
@@ -288,6 +288,15 @@ public class ProcessRunner : IDisposable
         if (_process == null)
             return true;
 
+        // ONE linked deadline across the WHOLE hook: invoking it (HTTP send / running the command) AND
+        // then waiting for the managed process to exit must TOGETHER fit inside hook.TimeoutSeconds —
+        // not once per phase. Previously the HTTP call (or an unbounded command wait) could consume the
+        // full timeout, and the managed-process wait a second full timeout, so a hung shutdown command
+        // could exceed the deadline and a total stop could take ~2x TimeoutSeconds.
+        using var deadlineCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        deadlineCts.CancelAfter(TimeSpan.FromSeconds(Math.Max(1, hook.TimeoutSeconds)));
+        var deadline = deadlineCts.Token;
+
         try
         {
             if (hook.Type == StopHookType.Http)
@@ -299,11 +308,17 @@ public class ProcessRunner : IDisposable
                 }
 
                 _logger.LogInformation("Invoking stop hook: {Method} {Url}", hook.Method, hook.Url);
-                using var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(Math.Max(5, hook.TimeoutSeconds)) };
+                // Timeout.InfiniteTimeSpan: the shared `deadline` token is the sole bound, so the HTTP
+                // call cannot outlive the hook deadline nor claim its own separate timeout budget.
+                using var httpClient = new HttpClient { Timeout = Timeout.InfiniteTimeSpan };
                 using var request = new HttpRequestMessage(new HttpMethod(hook.Method), hook.Url);
                 try
                 {
-                    await httpClient.SendAsync(request, cancellationToken);
+                    await httpClient.SendAsync(request, deadline);
+                }
+                catch (OperationCanceledException) when (deadline.IsCancellationRequested)
+                {
+                    _logger.LogWarning("Stop hook HTTP call did not complete within the {Timeout}s hook deadline", hook.TimeoutSeconds);
                 }
                 catch (Exception ex)
                 {
@@ -330,7 +345,13 @@ public class ProcessRunner : IDisposable
                 {
                     using var hookProcess = Process.Start(startInfo);
                     if (hookProcess != null)
-                        await hookProcess.WaitForExitAsync(cancellationToken);
+                        // Bound the command by the SHARED deadline, not the caller token — a hung
+                        // shutdown command can no longer exceed hook.TimeoutSeconds.
+                        await hookProcess.WaitForExitAsync(deadline);
+                }
+                catch (OperationCanceledException) when (deadline.IsCancellationRequested)
+                {
+                    _logger.LogWarning("Stop hook command did not complete within the {Timeout}s hook deadline", hook.TimeoutSeconds);
                 }
                 catch (Exception ex)
                 {
@@ -338,16 +359,14 @@ public class ProcessRunner : IDisposable
                 }
             }
 
-            // Wait for the MANAGED process to exit within the hook timeout.
-            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            timeoutCts.CancelAfter(TimeSpan.FromSeconds(Math.Max(1, hook.TimeoutSeconds)));
+            // Wait for the MANAGED process to exit within whatever remains of the SAME deadline.
             try
             {
-                await _process.WaitForExitAsync(timeoutCts.Token);
+                await _process.WaitForExitAsync(deadline);
             }
             catch (OperationCanceledException)
             {
-                // timed out waiting for exit — caller falls back to signal/kill
+                // deadline hit (hook + wait together) — caller falls back to signal/kill
             }
 
             return _process.HasExited;

--- a/src/WinLet.Core/ServiceConfig.cs
+++ b/src/WinLet.Core/ServiceConfig.cs
@@ -47,6 +47,46 @@ public class ProcessConfig
     /// Timeout in seconds for graceful shutdown
     /// </summary>
     public int ShutdownTimeoutSeconds { get; set; } = 30;
+
+    /// <summary>
+    /// Optional graceful stop hook invoked BEFORE any Ctrl+C / force kill: an HTTP request or a
+    /// command that asks the managed process to shut itself down cleanly (finish in-flight work).
+    /// Essential for a process mid-write to a database or file, where a force kill risks corruption.
+    /// </summary>
+    public StopHookConfig? StopHook { get; set; }
+}
+
+/// <summary>
+/// A graceful shutdown hook. On stop, WinLet invokes this first and waits for the managed process to
+/// exit; only if it does not exit within <see cref="TimeoutSeconds"/> does WinLet fall back to the
+/// Ctrl+C signal and then a force kill. Ideal for services that expose a shutdown endpoint or command.
+/// </summary>
+public class StopHookConfig
+{
+    /// <summary>How to request graceful shutdown: Http (default) or Command.</summary>
+    public StopHookType Type { get; set; } = StopHookType.Http;
+
+    /// <summary>For Type=Http: the URL to call, e.g. http://localhost:8730/admin/stop.</summary>
+    public string? Url { get; set; }
+
+    /// <summary>For Type=Http: the HTTP method (default POST).</summary>
+    public string Method { get; set; } = "POST";
+
+    /// <summary>For Type=Command: the executable to run.</summary>
+    public string? Command { get; set; }
+
+    /// <summary>For Type=Command: arguments passed to the executable.</summary>
+    public string? Arguments { get; set; }
+
+    /// <summary>Seconds to wait for the process to exit after invoking the hook (default 30).</summary>
+    public int TimeoutSeconds { get; set; } = 30;
+}
+
+/// <summary>How a <see cref="StopHookConfig"/> requests graceful shutdown.</summary>
+public enum StopHookType
+{
+    Http,
+    Command
 }
 
 /// <summary>


### PR DESCRIPTION
## Problem

When a service is stopped, WinLet sends **Ctrl+C** to the managed process and force-kills it after `shutdown_timeout_seconds`. But the managed process is launched with `CreateNoWindow = true` (no console), so `GenerateConsoleCtrlEvent` often can't deliver the Ctrl+C — the process ends up **force-killed** rather than shutting down gracefully. That's unsafe for anything mid-write to a database or file (corruption risk), and there's currently no way to ask the process to shut *itself* down cleanly first.

## Solution

An optional `[process.stop_hook]` that WinLet invokes **before** the Ctrl+C/kill sequence — either an HTTP request (e.g. `POST` to the app's shutdown endpoint) or a command — then waits up to `timeout_seconds` for the process to exit. Only if it doesn't exit in time does WinLet fall back to the existing Ctrl+C → force-kill path.

```toml
[process.stop_hook]
type = "http"
url = "http://localhost:3000/admin/stop"
method = "POST"
timeout_seconds = 30
```

A `type = "command"` variant runs an executable instead:

```toml
[process.stop_hook]
type = "command"
command = "C:\\Apps\\MyApp\\shutdown.exe"
arguments = "--graceful"
timeout_seconds = 30
```

## Backward compatible

- Omit `[process.stop_hook]` → behavior is unchanged (Ctrl+C → force kill).
- A failed or missing hook falls through to the default stop path and **never blocks a stop from completing**.

## Changes

- `ServiceConfig`: `ProcessConfig.StopHook` + `StopHookConfig` / `StopHookType`
- `ConfigLoader`: parse `[process.stop_hook]`
- `ProcessRunner.StopAsync`: invoke the hook first; `TryStopHookAsync` waits for a clean exit, never throws
- `CONFIGURATION.md`: documented with HTTP + command examples

## Tested

A Python HTTP daemon that traps its `/admin/stop` endpoint now exits cleanly in ~3s via the hook, instead of a ~15s force-kill. Verified via `sc stop`, confirmed in the WinLet log:

```
Invoking stop hook: POST http://localhost:8730/admin/stop
Process exited gracefully via stop hook
```

Thanks for WinLet — a clean, modern wrapper. This one feature made it a perfect fit for long-lived data-plane services that must never be killed mid-write. 🙏
